### PR TITLE
Allow the updates category ontop of the link index

### DIFF
--- a/.github/actions/alphabetical.php
+++ b/.github/actions/alphabetical.php
@@ -20,8 +20,12 @@ $categories = [];
 
 $links = [];
 
+$unordered_categories = [
+  '### Updates',
+];
+
 foreach($lines as $line) {
-  if (str_starts_with($line, '### ')) {
+  if (str_starts_with($line, '### ') && ! in_array($line, $unordered_categories)) {
     $category = $line;
     $categories[] = $line;
     $links = [];


### PR DESCRIPTION
This will prevent the github ci script from saying it's out of order.